### PR TITLE
enter key set to repsond to carriage return instead of line feed

### DIFF
--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -57,7 +57,7 @@ class Keyboard
             ],
             chr(127)    => 'backspace',
             chr(9)      => 'tab',
-            chr(10)     => 'enter'
+            chr(13)     => 'enter'
         ];
 
         $mapping = $multibyteChars;

--- a/tests/Functional/MultipleChoiceQuestionTest.php
+++ b/tests/Functional/MultipleChoiceQuestionTest.php
@@ -11,7 +11,7 @@ class MultipleChoiceQuestionTest extends \PHPUnit_Framework_TestCase
 {
     public function test_pressing_enter_selects_no_choices()
     {
-        $in = InputStreamStub::withInput(chr(10));
+        $in = InputStreamStub::withInput(chr(13));
         $out = OutputStreamSpy::create();
 
         $terminal = new Terminal($in, $out);
@@ -30,7 +30,7 @@ class MultipleChoiceQuestionTest extends \PHPUnit_Framework_TestCase
 
     public function test_pressing_down_then_space_then_enter_selects_second_choice()
     {
-        $in = InputStreamStub::withInput("\e[B " . chr(10));
+        $in = InputStreamStub::withInput("\e[B " . chr(13));
         $out = OutputStreamSpy::create();
 
         $terminal = new Terminal($in, $out);

--- a/tests/Functional/SingleChoiceQuestionTest.php
+++ b/tests/Functional/SingleChoiceQuestionTest.php
@@ -11,7 +11,7 @@ class SingleChoiceQuestionTest extends \PHPUnit_Framework_TestCase
 {
     public function test_pressing_enter_selects_first_choice()
     {
-        $in = InputStreamStub::withInput(chr(10));
+        $in = InputStreamStub::withInput(chr(13));
         $out = OutputStreamSpy::create();
 
         $terminal = new Terminal($in, $out);
@@ -30,7 +30,7 @@ class SingleChoiceQuestionTest extends \PHPUnit_Framework_TestCase
 
     public function test_choices_can_have_key_value_pairs()
     {
-        $in = InputStreamStub::withInput(chr(10));
+        $in = InputStreamStub::withInput(chr(13));
         $out = OutputStreamSpy::create();
 
         $terminal = new Terminal($in, $out);
@@ -56,7 +56,7 @@ class SingleChoiceQuestionTest extends \PHPUnit_Framework_TestCase
 
     public function test_pressing_down_then_enter_selects_second_choice()
     {
-        $in = InputStreamStub::withInput("\e[B" . chr(10));
+        $in = InputStreamStub::withInput("\e[B" . chr(13));
         $out = OutputStreamSpy::create();
 
         $terminal = new Terminal($in, $out);

--- a/tests/Functional/TextQuestionTest.php
+++ b/tests/Functional/TextQuestionTest.php
@@ -11,7 +11,7 @@ class TextQuestionTest extends \PHPUnit_Framework_TestCase
 {
     public function test_typing_string_then_enter_returns_valid_string()
     {
-        $in = InputStreamStub::withInput("World!" . chr(10));
+        $in = InputStreamStub::withInput("World!" . chr(13));
         $out = OutputStreamSpy::create();
 
         $terminal = new Terminal($in, $out);

--- a/tests/Unit/Keyboard/KeyboardTest.php
+++ b/tests/Unit/Keyboard/KeyboardTest.php
@@ -93,7 +93,7 @@ class KeyboardTest extends \PHPUnit_Framework_TestCase
     public function ansiCodeToMethodMappingDataProvider()
     {
         return [
-            [EnterKeyHandler::class,        chr(10),           'enter'],
+            [EnterKeyHandler::class,        chr(13),           'enter'],
             [ArrowKeyHandler::class,        chr(27) . "[A",    'upArrow'],
             [ArrowKeyHandler::class,        chr(27) . "[B",    'downArrow'],
             [ArrowKeyHandler::class,        chr(27) . "[C",    'rightArrow'],


### PR DESCRIPTION
The dialog helper in the symfony coolkit disables the stty setting that converts Carriage Returns to Line Feeds.

This remaps the enter key to the carriage return instead of the none received line feed.